### PR TITLE
Feature: Initial support for detecting arena AI type

### DIFF
--- a/src/utilities/bf-core/constants.js
+++ b/src/utilities/bf-core/constants.js
@@ -1,3 +1,5 @@
+import { ArenaCondition } from '@bluuarc/bfmt-utilities/dist/datamine-types';
+
 export const ELEMENT_NAME_MAPPING = Object.freeze({
 	dark: 'Dark',
 	earth: 'Earth',
@@ -69,3 +71,67 @@ export const BURST_TYPES = Object.freeze([
 	BURST_TYPE_MAPPING.SBB,
 	BURST_TYPE_MAPPING.UBB,
 ]);
+
+/**
+ * @type {{ [id: string]: import('@bluuarc/bfmt-utilities/dist/datamine-types').IUnitArenaAiEntry}}
+ */
+export const ARENA_ENTRIES_BY_TYPE = (() => {
+	/**
+	 * @param {'attack'|'skill'} action
+	 * @param {number} chance
+	 * @param {import('@bluuarc/bfmt-utilities/dist/datamine-types').ArenaCondition} condition
+	 * @param {'party'|'enemy'} target
+	 * @returns {import('@bluuarc/bfmt-utilities/dist/datamine-types').IUnitArenaAiEntry}
+	 */
+	const createArenaEntry = (action, chance, condition, target) => ({
+		action,
+		'chance%': chance,
+		'target conditions': condition,
+		'target type': target,
+	});
+	const SKILL_ACTION = 'skill';
+	const ATTACK_ACTION = 'attack';
+	const PARTY_TARGET = 'party';
+	const ENEMY_TARGET = 'enemy';
+	return Object.freeze({
+		1: [
+			createArenaEntry(SKILL_ACTION, 60, ArenaCondition.random, PARTY_TARGET),
+			createArenaEntry(ATTACK_ACTION, 30, ArenaCondition.atk_max, ENEMY_TARGET),
+			createArenaEntry(ATTACK_ACTION, 100, ArenaCondition.random, ENEMY_TARGET),
+		],
+		2: [
+			createArenaEntry(SKILL_ACTION, 60, ArenaCondition.hp_50pr_over, ENEMY_TARGET),
+			createArenaEntry(SKILL_ACTION, 20, ArenaCondition.random, ENEMY_TARGET),
+			createArenaEntry(ATTACK_ACTION, 100, ArenaCondition.random, ENEMY_TARGET),
+		],
+		3: [
+			createArenaEntry(SKILL_ACTION, 60, ArenaCondition.random, ENEMY_TARGET),
+			createArenaEntry(SKILL_ACTION, 20, ArenaCondition.atk_max, ENEMY_TARGET),
+			createArenaEntry(ATTACK_ACTION, 30, ArenaCondition.hp_min, ENEMY_TARGET),
+			createArenaEntry(ATTACK_ACTION, 100, ArenaCondition.random, ENEMY_TARGET),
+		],
+		4: [
+			createArenaEntry(SKILL_ACTION, 60, ArenaCondition.hp_50pr_under, ENEMY_TARGET),
+			createArenaEntry(SKILL_ACTION, 30, ArenaCondition.random, ENEMY_TARGET),
+			createArenaEntry(ATTACK_ACTION, 70, ArenaCondition.hp_max, ENEMY_TARGET),
+			createArenaEntry(ATTACK_ACTION, 50, ArenaCondition.hp_min, ENEMY_TARGET),
+			createArenaEntry(ATTACK_ACTION, 100, ArenaCondition.random, ENEMY_TARGET),
+		],
+		5: [
+			createArenaEntry(SKILL_ACTION, 80, ArenaCondition.hp_50pr_over, PARTY_TARGET),
+			createArenaEntry(SKILL_ACTION, 20, ArenaCondition.hp_min, PARTY_TARGET),
+			createArenaEntry(ATTACK_ACTION, 100, ArenaCondition.random, ENEMY_TARGET),
+		],
+		6: [
+			createArenaEntry(SKILL_ACTION, 100, ArenaCondition.hp_25pr_under, PARTY_TARGET),
+			createArenaEntry(ATTACK_ACTION, 50, ArenaCondition.atk_max, ENEMY_TARGET),
+			createArenaEntry(ATTACK_ACTION, 100, ArenaCondition.random, ENEMY_TARGET),
+		],
+		7: [
+			createArenaEntry(SKILL_ACTION, 100, ArenaCondition.hp_75pr_under, PARTY_TARGET),
+			createArenaEntry(ATTACK_ACTION, 50, ArenaCondition.hp_min, ENEMY_TARGET),
+			createArenaEntry(ATTACK_ACTION, 100, ArenaCondition.random, ENEMY_TARGET),
+		],
+		// NOTE: not in Deathmax data: types 8 - 13
+	});
+})();

--- a/src/utilities/bf-core/constants.js
+++ b/src/utilities/bf-core/constants.js
@@ -118,7 +118,7 @@ export const ARENA_ENTRIES_BY_TYPE = (() => {
 			createArenaEntry(ATTACK_ACTION, 100, ArenaCondition.random, ENEMY_TARGET),
 		],
 		5: [
-			createArenaEntry(SKILL_ACTION, 80, ArenaCondition.hp_50pr_over, PARTY_TARGET),
+			createArenaEntry(SKILL_ACTION, 80, ArenaCondition.hp_50pr_under, PARTY_TARGET),
 			createArenaEntry(SKILL_ACTION, 20, ArenaCondition.hp_min, PARTY_TARGET),
 			createArenaEntry(ATTACK_ACTION, 100, ArenaCondition.random, ENEMY_TARGET),
 		],

--- a/src/utilities/wiki/units.js
+++ b/src/utilities/wiki/units.js
@@ -571,6 +571,7 @@ function determineArenaAiType (unit) {
 
 		result = Object.keys(ARENA_ENTRIES_BY_TYPE).find((type) => {
 			const result = unitHasEntries(ARENA_ENTRIES_BY_TYPE[type]);
+			// logger.debug('arena ai comparison', { result, type, typeData: ARENA_ENTRIES_BY_TYPE[type], unitAi: ai });
 			return result;
 		});
 	}


### PR DESCRIPTION
When generating template data for units, the generator will look at any existing AI data for the unit and attempt to determine the arena type based on the [condition info on the wiki](https://bravefrontierglobal.fandom.com/wiki/Category:AI:Types). Due to how Deathmax's datamine is currently outputting AI data, only arena AI types 1-7 are supported.